### PR TITLE
👷(project) fix github workflow permissions

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches-ignore: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   fixup-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   release-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
By default, we do not need more that read permission for the
GITHUB_TOKEN used in CI workflows.

## Purpose

Description...

## Proposal

Description...

- [ ] item 1...
- [ ] item 2...
