### PR TITLE
🐛(api) allow play rank to be 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - CLI: Add the `openapi` command
 
+### Fixed
+
+- Allow to play queue from the first track (rank 0)
+
 ## [0.3.0] - 2025-10-05
 
 ### Added

--- a/src/onzr/client.py
+++ b/src/onzr/client.py
@@ -1,8 +1,9 @@
 """Onzr: http client."""
 
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 import requests
+from annotated_types import Ge
 
 from .config import get_settings
 from .models import (
@@ -57,7 +58,7 @@ class OnzrClient:
         return ServerState.model_validate_json(response.text)
 
     # Controls
-    def play(self, rank: Optional[int] = None) -> PlayerControl:
+    def play(self, rank: Optional[Annotated[int, Ge(0)]] = None) -> PlayerControl:
         """Start playing current queue."""
         params = PlayQueryParams(rank=rank)
         response = self.session.post(

--- a/src/onzr/models.py
+++ b/src/onzr/models.py
@@ -111,4 +111,4 @@ class PlayingState(BaseModel):
 class PlayQueryParams(BaseModel):
     """Play endpoint parameters."""
 
-    rank: Optional[Annotated[int, Field(strict=True, gt=0)]] = None
+    rank: Optional[Annotated[int, Field(strict=True, ge=0)]] = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,10 +398,16 @@ def test_play_command(test_server, configured_cli_runner, configured_onzr, track
     assert configured_onzr.player.is_playing() == 1
     assert configured_onzr.player.get_state() == vlc.State.Opening
 
-    # Play the second track in queue
+    # Play an invalid track rank
     result = configured_cli_runner.invoke(cli, ["play", "--rank", "0"])
     assert result.exit_code == ExitCodes.INVALID_ARGUMENTS
     assert "Invalid rank" in result.stdout
+
+    # Play the first track in queue
+    result = configured_cli_runner.invoke(cli, ["play", "--rank", "1"])
+    assert result.exit_code == ExitCodes.OK
+    assert configured_onzr.player.is_playing() == 1
+    assert configured_onzr.player.get_state() == vlc.State.Opening
 
     # Play the second track in queue
     result = configured_cli_runner.invoke(cli, ["play", "--rank", "2"])


### PR DESCRIPTION
## Purpose

We need to be able to play from the first queued track 😅

## Proposal

- [x] Allow the `rank` field to be `0` in the `PlayQueryParams` model
