### PR TITLE
🐛(deezer) use the best available quality if default not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - Allow to play queue from the first track (rank 0)
+- Use the best available quality if the default quality is not available
 
 ## [0.3.0] - 2025-10-05
 

--- a/src/onzr/exceptions.py
+++ b/src/onzr/exceptions.py
@@ -3,3 +3,7 @@
 
 class OnzrConfigurationError(Exception):
     """Raised when onzr cannot load or create its configuration."""
+
+
+class DeezerTrackException(Exception):
+    """Raised when onzr cannot handle a Deezer track."""

--- a/src/onzr/models.py
+++ b/src/onzr/models.py
@@ -1,5 +1,6 @@
 """Onzr: Pydantic models."""
 
+from enum import StrEnum
 from typing import Annotated, List, Optional, TypeAlias
 
 from pydantic import BaseModel, Field
@@ -18,6 +19,21 @@ class ServerState(BaseModel):
     # Does not support VLC Enums
     player: str
     queue: QueueState
+
+
+class StreamQuality(StrEnum):
+    """Track stream quality."""
+
+    MP3_128 = "MP3_128"
+    MP3_320 = "MP3_320"
+    FLAC = "FLAC"
+
+    @property
+    def media_type(self) -> str:
+        """Get media type corresponding to selected quality."""
+        if self == StreamQuality.FLAC:
+            return "audio/flac"
+        return "audio/mpeg"
 
 
 class PlayerControl(BaseModel):
@@ -72,6 +88,7 @@ class TrackInfo(BaseModel):
     picture: str
     token: str
     duration: int
+    formats: List[StreamQuality]
 
 
 Collection: TypeAlias = List[ArtistShort] | List[AlbumShort] | List[TrackShort]

--- a/src/onzr/server.py
+++ b/src/onzr/server.py
@@ -82,11 +82,11 @@ async def stream_track(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Track rank out of range."
         )
-    quality = settings.QUALITY
     onzr.queue.playing = rank
     track = onzr.queue[rank]
-    # Refresh track token to avoid having an expired one
+    # Refresh track token in case it expired
     track.refresh()
+    quality = track.query_quality(settings.QUALITY)
     return StreamingResponse(track.stream(quality), media_type=quality.media_type)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -20,6 +20,9 @@ class DeezerSong(BaseModel):
     SNG_TITLE: str
     ALB_TITLE: str
     ALB_PICTURE: str
+    FILESIZE_MP3_128: int
+    FILESIZE_MP3_320: int
+    FILESIZE_FLAC: int
 
 
 class DeezerSongResponse(BaseDeezerGWResponse):


### PR DESCRIPTION
## Purpose

Default track quality configured in settings may not be available for some tracks. In this case, the server fails to get the track URL, cannot stream it and hangs.

## Proposal

- [x] use the best available quality if default quality is not available
