### PR TITLE
🔖(minor) bump release to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-10-22
+
 ### Added
 
 - CLI: Add the `config` command
@@ -67,8 +69,9 @@ and this project adheres to
 
 - Implement a draft CLI using VLC
 
-[unreleased]: https://github.com/jmaupetit/onzr/compare/v0.3.0...main
+[unreleased]: https://github.com/jmaupetit/onzr/compare/v0.4.0...main
 
+[0.4.0] https://github.com/jmaupetit/onzr/compare/v0.3.0...v0.4.0
 [0.3.0] https://github.com/jmaupetit/onzr/compare/v0.2.0...v0.3.0
 [0.2.0] https://github.com/jmaupetit/onzr/compare/v0.1.0...v0.2.0
 [0.1.0] https://github.com/jmaupetit/onzr/compare/13ca0d7...v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onzr"
-version = "0.4.0.dev1"
+version = "0.4.0"
 description = "The one-hour-late Deezer CLI."
 authors = [{ name = "Julien Maupetit", email = "julien@maupetit.net" }]
 requires-python = ">3.10,<4.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ wheels = [
 
 [[package]]
 name = "onzr"
-version = "0.4.0.dev1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "deezer-py" },


### PR DESCRIPTION
### Added

- CLI: Add the `config` command
- CLI: Add the `openapi` command
- CLI: Add configurable `THEME`

### Changed

- CLI: Improve commands output (`now` command is no longer experimental)

### Fixed

- Allow to play queue from the first track (rank 0)
- Use the best available quality if the default quality is not available
