### PR TITLE
🐛(deezer) store song version in track title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - CLI: add all command options short name
 - CLI: add `--first/-f` option to the `search` command
 
+### Fixed
+
+- Store song version in track title
+
 ## [0.4.0] - 2025-10-22
 
 ### Added

--- a/src/onzr/deezer.py
+++ b/src/onzr/deezer.py
@@ -233,7 +233,11 @@ class Track:
             token=track_info["TRACK_TOKEN"],
             duration=track_info["DURATION"],
             artist=track_info["ART_NAME"],
-            title=track_info["SNG_TITLE"],
+            title=(
+                f"{track_info['SNG_TITLE']} {track_info['VERSION']}"
+                if track_info["VERSION"]
+                else track_info["SNG_TITLE"]
+            ),
             album=track_info["ALB_TITLE"],
             picture=track_info["ALB_PICTURE"],
             formats=[

--- a/tests/models.py
+++ b/tests/models.py
@@ -18,6 +18,7 @@ class DeezerSong(BaseModel):
     DURATION: int
     ART_NAME: str
     SNG_TITLE: str
+    VERSION: str = ""
     ALB_TITLE: str
     ALB_PICTURE: str
     FILESIZE_MP3_128: int


### PR DESCRIPTION
## Purpose

Some songs (e.g. remixes) have the same title as their original songs, but their version is described in the specific `VERSION` field. We should keep that information in track titles  when handling tracks in queue.

## Proposal

- [x] Store the song vesion in the track title when available
