### PR TITLE
🐛(deezer) fix track title when version is not in the payload

### DIFF
--- a/src/onzr/deezer.py
+++ b/src/onzr/deezer.py
@@ -235,7 +235,7 @@ class Track:
             artist=track_info["ART_NAME"],
             title=(
                 f"{track_info['SNG_TITLE']} {track_info['VERSION']}"
-                if track_info["VERSION"]
+                if "VERSION" in track_info and track_info["VERSION"]
                 else track_info["SNG_TITLE"]
             ),
             album=track_info["ALB_TITLE"],

--- a/tests/models.py
+++ b/tests/models.py
@@ -18,7 +18,7 @@ class DeezerSong(BaseModel):
     DURATION: int
     ART_NAME: str
     SNG_TITLE: str
-    VERSION: str = ""
+    VERSION: str | None = None
     ALB_TITLE: str
     ALB_PICTURE: str
     FILESIZE_MP3_128: int

--- a/tests/test_deezer.py
+++ b/tests/test_deezer.py
@@ -160,7 +160,7 @@ def test_track_init(configured_onzr, responses):
     ):
         Track(client=configured_onzr.deezer, track_id=track_id, background=False)
 
-    # Test when no version is supplied
+    # Test when no version is supplied (empty string)
     responses.post(
         "http://www.deezer.com/ajax/gw-light.php",
         status=200,
@@ -180,6 +180,33 @@ def test_track_init(configured_onzr, responses):
                 FILESIZE_FLAC=track_filesize_flac,
             ),
         ).model_dump(),
+    )
+
+    track = Track(client=configured_onzr.deezer, track_id=track_id, background=False)
+    assert track.title == track_title
+
+    # Test when no version is supplied (field not in payload)
+    payload = DeezerSongResponseFactory.build(
+        error={},
+        results=DeezerSongFactory.build(
+            SNG_ID=track_id,
+            TRACK_TOKEN=track_token,
+            DURATION=track_duration,
+            ART_NAME=track_artist,
+            SNG_TITLE=track_title,
+            ALB_TITLE=track_album,
+            ALB_PICTURE=track_picture,
+            FILESIZE_MP3_128=track_filesize_mp3_128,
+            FILESIZE_MP3_320=track_filesize_mp3_320,
+            FILESIZE_FLAC=track_filesize_flac,
+        ),
+    )
+    del payload.results.VERSION
+
+    responses.post(
+        "http://www.deezer.com/ajax/gw-light.php",
+        status=200,
+        json=payload.model_dump(),
     )
 
     track = Track(client=configured_onzr.deezer, track_id=track_id, background=False)


### PR DESCRIPTION
## Purpose

Recent changes in implementing track version support introduced a regression: some tracks cannot be played when the `VERSION` field is not in track details payload.

## Proposal

- [x] check if the field exists prior to detecting its value
