### PR TITLE
Add user data support

### DIFF
--- a/src/onzr/cli.py
+++ b/src/onzr/cli.py
@@ -11,7 +11,7 @@ from importlib.metadata import version as import_lib_version
 from operator import attrgetter
 from pathlib import Path
 from random import randint, shuffle
-from typing import List, Set, cast
+from typing import List, Optional, Set, cast
 
 import click
 import pendulum
@@ -36,7 +36,7 @@ from .config import (
     get_onzr_dir,
     get_settings,
 )
-from .deezer import AlbumSortBy, DeezerClient
+from .deezer import AlbumSortBy, DeezerClient, TrackSortBy
 from .models.core import (
     AlbumShort,
     ArtistShort,
@@ -562,6 +562,39 @@ def my_albums(
 
     with console.pager(styles=True):
         print_collection_table(albums, title=f"{deezer.user.name}'s albums", sort=False)
+
+
+@my.command("tracks")
+def my_tracks(
+    by: Annotated[
+        Optional[TrackSortBy],
+        typer.Option("--by", "-b", help="Sort by title, album or artist."),
+    ] = None,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Quiet output.")] = False,
+    ids: Annotated[
+        bool, typer.Option("--ids", "-i", help="Show only result IDs.")
+    ] = False,
+):
+    """Get your favorite tracks."""
+    if ids:
+        quiet = True
+
+    deezer = get_deezer_client(quiet=quiet, fast=True)
+
+    playlist = deezer.user_tracks(sort_by=by)
+
+    if not playlist.tracks:
+        console.print("No favorite tracks for user.")
+        return
+
+    if ids:
+        print_collection_ids(playlist.tracks)
+        return
+
+    with console.pager(styles=True):
+        print_collection_table(
+            playlist.tracks, title=f"{deezer.user.name}'s tracks", sort=False
+        )
 
 
 @cli.command()

--- a/src/onzr/cli.py
+++ b/src/onzr/cli.py
@@ -64,6 +64,8 @@ logging_config = {
 logging.config.dictConfig(logging_config)
 
 cli = typer.Typer(name="onzr", no_args_is_help=True, pretty_exceptions_short=True)
+my = typer.Typer(name="my", no_args_is_help=True, pretty_exceptions_short=True)
+cli.add_typer(my, name="my", help="Explore your 💜 library.")
 console = Console()
 logger = logging.getLogger(__name__)
 
@@ -85,7 +87,7 @@ class ExitCodes(IntEnum):
     SERVER_DOWN = 40
 
 
-def get_deezer_client(quiet: bool = False) -> DeezerClient:
+def get_deezer_client(quiet: bool = False, fast: bool = True) -> DeezerClient:
     """Get Deezer client for simple API queries."""
     settings = get_settings()
 
@@ -95,7 +97,7 @@ def get_deezer_client(quiet: bool = False) -> DeezerClient:
     return DeezerClient(
         arl=settings.ARL,
         blowfish=settings.DEEZER_BLOWFISH_SECRET,
-        fast=True,
+        fast=fast,
         connection_pool_maxsize=settings.CONNECTION_POOL_MAXSIZE,
         always_fetch_release_date=settings.ALWAYS_FETCH_RELEASE_DATE,
     )
@@ -486,6 +488,30 @@ def mix(
         return
 
     print_collection_table(tracks, title="Onzr Mix tracks")
+
+
+@my.command("playlists")
+def my_playlists(
+    private: Annotated[
+        bool, typer.Option("--private", "-p", help="Restrict to private playlists.")
+    ] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Quiet output.")] = False,
+    ids: Annotated[
+        bool, typer.Option("--ids", "-i", help="Show only result IDs.")
+    ] = False,
+):
+    """Get your playlists."""
+    if ids:
+        quiet = True
+
+    deezer = get_deezer_client(quiet=quiet, fast=True)
+
+    playlists = deezer.user_playlists(private)
+    if ids:
+        print_collection_ids(playlists)
+        return
+
+    print_collection_table(playlists, title=f"{deezer.user.name}'s playlists")
 
 
 @cli.command()

--- a/src/onzr/cli.py
+++ b/src/onzr/cli.py
@@ -51,7 +51,7 @@ FORMAT = "%(message)s"
 logging_console = Console(stderr=True)
 logging_config = {
     "version": 1,
-    "level": logging.INFO,
+    "level": logging.DEBUG,
     "format": FORMAT,
     "datefmt": "[%X]",
     "handlers": {
@@ -512,6 +512,27 @@ def my_playlists(
         return
 
     print_collection_table(playlists, title=f"{deezer.user.name}'s playlists")
+
+
+@my.command("artists")
+def my_artists(
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Quiet output.")] = False,
+    ids: Annotated[
+        bool, typer.Option("--ids", "-i", help="Show only result IDs.")
+    ] = False,
+):
+    """Get your favorite artists."""
+    if ids:
+        quiet = True
+
+    deezer = get_deezer_client(quiet=quiet, fast=True)
+
+    artists = deezer.user_artists()
+    if ids:
+        print_collection_ids(artists)
+        return
+
+    print_collection_table(artists, title=f"{deezer.user.name}'s artists")
 
 
 @cli.command()

--- a/src/onzr/cli.py
+++ b/src/onzr/cli.py
@@ -10,7 +10,7 @@ from functools import cache, wraps
 from importlib.metadata import version as import_lib_version
 from operator import attrgetter
 from pathlib import Path
-from random import shuffle
+from random import randint, shuffle
 from typing import List, Set, cast
 
 import click
@@ -36,7 +36,7 @@ from .config import (
     get_onzr_dir,
     get_settings,
 )
-from .deezer import DeezerClient
+from .deezer import AlbumSortBy, DeezerClient
 from .models.core import (
     AlbumShort,
     ArtistShort,
@@ -51,7 +51,7 @@ FORMAT = "%(message)s"
 logging_console = Console(stderr=True)
 logging_config = {
     "version": 1,
-    "level": logging.DEBUG,
+    "level": logging.INFO,
     "format": FORMAT,
     "datefmt": "[%X]",
     "handlers": {
@@ -128,12 +128,14 @@ def print_collection_ids(collection: Collection):
         console.print(item.id)
 
 
-def print_collection_table(collection: Collection, title="Collection"):
+def print_collection_table(
+    collection: Collection, title="Collection", sort: bool = True
+):
     """Print a collection as a table."""
     theme = get_theme()
     table = Table(title=title)
 
-    sample = collection[0]
+    sample = collection[randint(0, len(collection) - 1)]
     show_artist = (
         True
         if isinstance(sample, TrackShort)
@@ -167,7 +169,7 @@ def print_collection_table(collection: Collection, title="Collection"):
         table.add_column("Released")
 
     # Sort albums by release date
-    if isinstance(sample, AlbumShort):
+    if isinstance(sample, AlbumShort) and sort:
         albums_with_release_date: Set[AlbumShort] = set(
             filter(attrgetter("release_date"), collection)  # type: ignore[arg-type]
         )
@@ -511,7 +513,8 @@ def my_playlists(
         print_collection_ids(playlists)
         return
 
-    print_collection_table(playlists, title=f"{deezer.user.name}'s playlists")
+    with console.pager(styles=True):
+        print_collection_table(playlists, title=f"{deezer.user.name}'s playlists")
 
 
 @my.command("artists")
@@ -532,7 +535,33 @@ def my_artists(
         print_collection_ids(artists)
         return
 
-    print_collection_table(artists, title=f"{deezer.user.name}'s artists")
+    with console.pager(styles=True):
+        print_collection_table(artists, title=f"{deezer.user.name}'s artists")
+
+
+@my.command("albums")
+def my_albums(
+    by: Annotated[
+        AlbumSortBy, typer.Option("--by", "-b", help="Sort by title or artist.")
+    ] = AlbumSortBy.TITLE,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Quiet output.")] = False,
+    ids: Annotated[
+        bool, typer.Option("--ids", "-i", help="Show only result IDs.")
+    ] = False,
+):
+    """Get your favorite albums."""
+    if ids:
+        quiet = True
+
+    deezer = get_deezer_client(quiet=quiet, fast=True)
+
+    albums = deezer.user_albums(sort_by=by)
+    if ids:
+        print_collection_ids(albums)
+        return
+
+    with console.pager(styles=True):
+        print_collection_table(albums, title=f"{deezer.user.name}'s albums", sort=False)
 
 
 @cli.command()

--- a/src/onzr/deezer.py
+++ b/src/onzr/deezer.py
@@ -431,6 +431,21 @@ class DeezerClient(deezer.Deezer):
         )
         return list(filter(lambda p: not p.public, playlists)) if private else playlists
 
+    def user_artists(self) -> List[ArtistShort]:
+        """Get logged in user favorite artists."""
+        return sorted(
+            cast(
+                List[ArtistShort],
+                self._api(
+                    DeezerArtist,
+                    self.gw.get_user_artists,
+                    callback=lambda c: [a.to_short() for a in c],
+                    user_id=self.user.id,
+                ),
+            ),
+            key=lambda a: a.name,
+        )
+
 
 class TrackStatus(IntEnum):
     """Track statuses."""

--- a/src/onzr/deezer.py
+++ b/src/onzr/deezer.py
@@ -61,6 +61,14 @@ class AlbumSortBy(StrEnum):
     TITLE = "title"
 
 
+class TrackSortBy(StrEnum):
+    """Track list sort field."""
+
+    ALBUM = "album"
+    ARTIST = "artist"
+    TITLE = "title"
+
+
 class DeezerClient(deezer.Deezer):
     """A wrapper for the Deezer API client."""
 
@@ -468,6 +476,16 @@ class DeezerClient(deezer.Deezer):
             ),
             key=attrgetter(sort_by),
         )
+
+    def user_tracks(self, sort_by: Optional[TrackSortBy] = None) -> PlaylistShort:
+        """Get logged in user favorite tracks."""
+        # Get the favorite tracks playlist identifier
+        response = self.gw.get_user_favorite_ids(checksum=None, limit=0, start=0)
+        playlist_id = response["playlist_id"]
+        playlist = self.playlist(playlist_id)
+        if playlist.tracks and sort_by:
+            playlist.tracks = sorted(playlist.tracks, key=attrgetter(sort_by))
+        return playlist
 
 
 class TrackStatus(IntEnum):

--- a/src/onzr/deezer.py
+++ b/src/onzr/deezer.py
@@ -13,11 +13,13 @@ from typing import Any, Callable, Iterator, List, Optional, cast
 import deezer
 import requests
 from Cryptodome.Cipher import Blowfish
+from deezer.errors import PermissionException
 from pydantic import HttpUrl
 
 from .exceptions import DeezerTrackException
 from .models.core import (
     AlbumShort,
+    ArtistShort,
     Collection,
     PlaylistShort,
     StreamQuality,
@@ -28,11 +30,13 @@ from .models.deezer import (
     DeezerAdvancedSearchResponse,
     DeezerAlbum,
     DeezerAlbumResponse,
+    DeezerAPIResponseCollection,
     DeezerArtist,
     DeezerArtistAlbumsResponse,
     DeezerArtistRadioResponse,
     DeezerArtistResponse,
     DeezerArtistTopResponse,
+    DeezerGWPlaylistResponse,
     DeezerPlaylist,
     DeezerSearchAlbumResponse,
     DeezerSearchArtistResponse,
@@ -41,10 +45,9 @@ from .models.deezer import (
     DeezerSearchTrackResponse,
     DeezerSong,
     DeezerTrack,
-    to_albums,
-    to_artists,
-    to_playlists,
-    to_tracks,
+    DeezerUser,
+    DeezerUserData,
+    DeezerUserProfilePageTabPlaylists,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,6 +84,7 @@ class DeezerClient(deezer.Deezer):
             self._fast_login()
         else:
             self._login()
+        self._user: Optional[DeezerUser] = None
 
     def _login(self):
         """Login to deezer API."""
@@ -117,12 +121,12 @@ class DeezerClient(deezer.Deezer):
 
         def get_track(id_: int) -> TrackShort:
             return cast(
-                DeezerTrack, self._api(DeezerTrack, self.api.get_track, id_)
+                DeezerTrack, self._api(DeezerTrack, self.api.get_track, song_id=id_)
             ).to_short()
 
         def get_album(id_: int) -> AlbumShort:
             return cast(
-                DeezerAlbum, self._api(DeezerAlbum, self.api.get_album, id_)
+                DeezerAlbum, self._api(DeezerAlbum, self.api.get_album, album_id=id_)
             ).to_short()
 
         sample = collection[0]
@@ -158,6 +162,13 @@ class DeezerClient(deezer.Deezer):
         # Preserve collection ordering
         return sorted(new, key=lambda i: order[i.id])
 
+    @staticmethod
+    def _collection_to_short(
+        collection: DeezerAPIResponseCollection, *args, **kwargs
+    ) -> Collection:
+        """Convert API response collection to a collection."""
+        return [item.to_short() for item in collection.data]
+
     def _api(
         self,
         model: (
@@ -165,21 +176,29 @@ class DeezerClient(deezer.Deezer):
             | type[DeezerAlbumResponse]
             | type[DeezerArtist]
             | type[DeezerArtistResponse]
+            | type[DeezerGWPlaylistResponse]
             | type[DeezerPlaylist]
+            | type[DeezerUserProfilePageTabPlaylists]
             | type[DeezerSearchResponse]
+            | type[DeezerSong]
             | type[DeezerTrack]
+            | type[DeezerUserData]
         ),
         endpoint: Callable,
+        callback: Callable | None = None,
         *args,
         **kwargs,
     ) -> (
-        DeezerAlbum
+        Any
+        | DeezerAlbum
         | DeezerAlbumResponse
         | DeezerArtist
         | DeezerArtistResponse
         | DeezerPlaylist
         | DeezerSearchResponse
         | DeezerTrack
+        | DeezerUser
+        | List[PlaylistShort]
     ):
         """An API proxy that validates response using the input model."""
         logger.debug(f"Will query {endpoint=} to {model=} with {args=}/{kwargs=}")
@@ -187,9 +206,13 @@ class DeezerClient(deezer.Deezer):
         response = endpoint(*args, **kwargs)
         logger.debug(pformat(response, sort_dicts=True))
 
-        instance = model(**response)
+        instance = (
+            model(**response)
+            if not isinstance(response, List)
+            else [model(**item) for item in response]
+        )
         logger.debug(f"{instance=}")
-        return instance
+        return callback(instance) if callback else instance
 
     def artist(
         self,
@@ -202,53 +225,45 @@ class DeezerClient(deezer.Deezer):
     ) -> Collection:
         """Get artist tracks."""
         artist = cast(
-            DeezerArtist, self._api(DeezerArtist, self.api.get_artist, artist_id)
+            DeezerArtist,
+            self._api(DeezerArtist, self.api.get_artist, artist_id=artist_id),
         ).to_short()
         logger.debug(f"{artist=}")
         results: Collection = []
 
         if radio:
-            results = list(
-                to_tracks(
-                    cast(
-                        DeezerArtistRadioResponse,
-                        self._api(
-                            DeezerArtistRadioResponse,
-                            self.api.get_artist_radio,
-                            artist.id,
-                            limit=limit,
-                        ),
-                    )
-                )
+            results = cast(
+                List[TrackShort],
+                self._api(
+                    DeezerArtistRadioResponse,
+                    self.api.get_artist_radio,
+                    callback=self._collection_to_short,
+                    artist_id=artist.id,
+                    limit=limit,
+                ),
             )
+
         elif top:
-            results = list(
-                to_tracks(
-                    cast(
-                        DeezerArtistTopResponse,
-                        self._api(
-                            DeezerArtistTopResponse,
-                            self.api.get_artist_top,
-                            artist.id,
-                            limit=limit,
-                        ),
-                    )
-                )
+            results = cast(
+                List[TrackShort],
+                self._api(
+                    DeezerArtistTopResponse,
+                    self.api.get_artist_top,
+                    callback=self._collection_to_short,
+                    artist_id=artist.id,
+                    limit=limit,
+                ),
             )
         elif albums:
-            results = list(
-                to_albums(
-                    cast(
-                        DeezerArtistAlbumsResponse,
-                        self._api(
-                            DeezerArtistAlbumsResponse,
-                            self.api.get_artist_albums,
-                            artist.id,
-                            limit=limit,
-                        ),
-                    ),
-                    artist=artist,
-                )
+            results = cast(
+                List[AlbumShort],
+                self._api(
+                    DeezerArtistAlbumsResponse,
+                    self.api.get_artist_albums,
+                    callback=lambda c: self._collection_to_short(c, artist=artist),
+                    artist_id=artist.id,
+                    limit=limit,
+                ),
             )
         else:
             raise ValueError(
@@ -265,22 +280,49 @@ class DeezerClient(deezer.Deezer):
         return list(
             cast(
                 DeezerAlbumResponse,
-                self._api(DeezerAlbumResponse, self.api.get_album, album_id),
+                self._api(DeezerAlbumResponse, self.api.get_album, album_id=album_id),
             ).get_tracks()
         )
 
     def track(self, track_id: int) -> TrackShort:
         """Get track info."""
         return cast(
-            DeezerTrack, self._api(DeezerTrack, self.api.get_track, track_id)
+            DeezerTrack, self._api(DeezerTrack, self.api.get_track, song_id=track_id)
         ).to_short()
 
     def playlist(self, playlist_id: int) -> PlaylistShort:
         """Get playlist tracks."""
-        return cast(
-            DeezerPlaylist,
-            self._api(DeezerPlaylist, self.api.get_playlist, playlist_id),
-        ).to_short()
+        # Supposed it's a public playlist
+        try:
+            playlist = cast(
+                DeezerPlaylist,
+                self._api(
+                    DeezerPlaylist, self.api.get_playlist, playlist_id=playlist_id
+                ),
+            ).to_short()
+        # Looks like it's a private playlist
+        except PermissionException:
+            # We've only the 10-first tracks of the playlist here
+            playlist = cast(
+                DeezerGWPlaylistResponse,
+                self._api(
+                    DeezerGWPlaylistResponse,
+                    self.gw.get_playlist,
+                    playlist_id=playlist_id,
+                ),
+            ).to_short()
+            # Get all playlist tracks
+            playlist.tracks = cast(
+                List[TrackShort],
+                self._api(
+                    DeezerSong,
+                    self.gw.get_playlist_tracks,
+                    callback=lambda x: [s.to_short() for s in x],
+                    playlist_id=playlist_id,
+                ),
+            )
+
+        return playlist
 
     def search(
         self,
@@ -300,72 +342,94 @@ class DeezerClient(deezer.Deezer):
             logger.error(msg)
             raise ValueError(msg)
         elif len(criteria) > 1:
-            results = list(
-                to_tracks(
-                    cast(
-                        DeezerAdvancedSearchResponse,
-                        self._api(
-                            DeezerAdvancedSearchResponse,
-                            self.api.advanced_search,
-                            artist=artist,
-                            album=album,
-                            track=track,
-                            strict=strict,
-                        ),
-                    )
-                )
+            results = cast(
+                List[TrackShort],
+                self._api(
+                    DeezerAdvancedSearchResponse,
+                    self.api.advanced_search,
+                    callback=self._collection_to_short,
+                    artist=artist,
+                    album=album,
+                    track=track,
+                    strict=strict,
+                ),
             )
         elif artist:
-            results = list(
-                to_artists(
-                    cast(
-                        DeezerSearchArtistResponse,
-                        self._api(
-                            DeezerSearchArtistResponse, self.api.search_artist, artist
-                        ),
-                    )
-                )
+            results = cast(
+                List[ArtistShort],
+                self._api(
+                    DeezerSearchArtistResponse,
+                    self.api.search_artist,
+                    callback=self._collection_to_short,
+                    query=artist,
+                ),
             )
         elif album:
-            results = list(
-                to_albums(
-                    cast(
-                        DeezerSearchAlbumResponse,
-                        self._api(
-                            DeezerSearchAlbumResponse, self.api.search_album, album
-                        ),
-                    )
-                )
+            results = cast(
+                List[AlbumShort],
+                self._api(
+                    DeezerSearchAlbumResponse,
+                    self.api.search_album,
+                    callback=self._collection_to_short,
+                    query=album,
+                ),
             )
+
         elif track:
-            results = list(
-                to_tracks(
-                    cast(
-                        DeezerSearchTrackResponse,
-                        self._api(
-                            DeezerSearchTrackResponse, self.api.search_track, track
-                        ),
-                    ),
-                )
+            results = cast(
+                List[TrackShort],
+                self._api(
+                    DeezerSearchTrackResponse,
+                    self.api.search_track,
+                    callback=self._collection_to_short,
+                    query=track,
+                ),
             )
         elif playlist:
-            results = list(
-                to_playlists(
-                    cast(
-                        DeezerSearchPlaylistResponse,
-                        self._api(
-                            DeezerSearchPlaylistResponse,
-                            self.api.search_playlist,
-                            playlist,
-                        ),
-                    ),
-                )
+            results = cast(
+                List[PlaylistShort],
+                self._api(
+                    DeezerSearchPlaylistResponse,
+                    self.api.search_playlist,
+                    callback=self._collection_to_short,
+                    query=playlist,
+                ),
             )
 
         if (self.always_fetch_release_date or fetch_release_date) and not artist:
             results = self._collection_details(results)
 
         return results
+
+    @property
+    def user(self) -> DeezerUser:
+        """Get logged in user."""
+        if self._user is None:
+            self._user = cast(
+                DeezerUser,
+                self._api(
+                    DeezerUserData,
+                    self.gw.get_user_data,
+                    callback=lambda r: r.USER.to_user(),
+                ),
+            )
+        return self._user
+
+    def user_playlists(self, private: bool = False) -> List[PlaylistShort]:
+        """Get logged in user public and private playlists."""
+        playlists = cast(
+            List[PlaylistShort],
+            self._api(
+                DeezerUserProfilePageTabPlaylists,
+                self.gw.get_user_profile_page,
+                callback=lambda r: [
+                    p.to_short(user=self.user.name) for p in r.TAB.playlists.data
+                ],
+                user_id=self.user.id,
+                tab="playlists",
+            ),
+        )
+        return list(filter(lambda p: not p.public, playlists)) if private else playlists
 
 
 class TrackStatus(IntEnum):

--- a/src/onzr/models/deezer.py
+++ b/src/onzr/models/deezer.py
@@ -118,7 +118,9 @@ class DeezerPlaylist(BaseDeezerModel):
             user=(
                 self.creator.name
                 if self.creator
-                else self.user.name if self.user else None
+                else self.user.name
+                if self.user
+                else None
             ),
             tracks=(
                 [track.to_short() for track in self.tracks.data]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -27,6 +27,11 @@ class DeezerSongFactory(ModelFactory[DeezerSong]):
     """DeezerSong factory."""
 
     @classmethod
+    def PHYSICAL_RELEASE_DATE(cls) -> str:
+        """Always generate a release date."""
+        return cls.__faker__.date()
+
+    @classmethod
     def FILESIZE_MP3_128(cls) -> PositiveInt:
         """Force FILESIZE_MP3_128 to be at least 100."""
         return cls.__random__.randint(100, 10000)


### PR DESCRIPTION
## Purpose

We need to be able to explore user account data.

## Proposal

- [x] add (private) user playlists support: `onzr my playlists --private`
- [x] add user albums support: `onzr my albums`
- [x] add user albums support: `onzr my artists`
- [x] add user tracks support: `onzr my tracks`
- [ ] add tests
- [ ] update the CHANGELOG
- [ ] update the documentation
